### PR TITLE
Changes to handle the validity of the Oauth 2.0 token

### DIFF
--- a/MVP/Private/Get-MVPOAuthAutorizationCode.ps1
+++ b/MVP/Private/Get-MVPOAuthAutorizationCode.ps1
@@ -84,7 +84,7 @@ Process {
             Uri = 'https://login.live.com/oauth20_token.srf'
             Method = 'Post'
             ContentType = 'application/x-www-form-urlencoded'
-            Body = 'client_id={0}&grant_type=refresh_token&redirect_uri={1}&refresh_token={2}' -f $ClientID,$RedirectUri,$Oauth2.refresh_token
+            Body = 'client_id={0}&grant_type=refresh_token&redirect_uri={1}&refresh_token={2}' -f $ClientID,$RedirectUri,$MVPOauth2.refresh_token
         }
         try {
             $r = Invoke-RestMethod @HashTable -ErrorAction Stop

--- a/MVP/Private/Get-MVPOAuthAutorizationCode.ps1
+++ b/MVP/Private/Get-MVPOAuthAutorizationCode.ps1
@@ -55,27 +55,50 @@ Begin {
 
 }
 Process {
-
-    Show-MVPOAuthWindow -url $u1
-    
-    if ($AutorizationCode) {
-    
+    if (-not($MVPOauth2)) {
+        Write-Verbose -Message 'No Ouath2 object detected, asking for permission'
+        Show-MVPOAuthWindow -url $u1
+        if ($AutorizationCode) {
+            $HashTable = @{
+                Uri = 'https://login.live.com/oauth20_token.srf'
+                Method = 'Post'
+                ContentType = 'application/x-www-form-urlencoded'
+                Body = 'client_id={0}&redirect_uri={1}&client_secret={2}&code={3}&grant_type=authorization_code' -f  $ClientID,$RedirectUri,$SubscriptionKey,$AutorizationCode
+            }
+            try {
+                $r = Invoke-RestMethod @HashTable -ErrorAction Stop
+                Write-Verbose -Message 'Successfully got oauth 2.0 access token'
+            } catch {
+                Throw $_
+            }
+            if ($r) {
+                $global:MVPOauth2 = $r | 
+                Add-Member -MemberType NoteProperty -Name ValidUntil -Value ((Get-Date).AddSeconds($r.expires_in-1)) -Force -PassThru
+            }
+        } else {
+            Write-Warning -Message 'No authorization code set'
+        }        
+    } elseif ((Get-Date) -ge ($MVPOauth2.ValidUntil)) {
+        Write-Verbose -Message 'Expired Ouath2 access token detected, refreshing it'
         $HashTable = @{
             Uri = 'https://login.live.com/oauth20_token.srf'
             Method = 'Post'
             ContentType = 'application/x-www-form-urlencoded'
-            Body = 'client_id={0}&redirect_uri={1}&client_secret={2}&code={3}&grant_type=authorization_code' -f  $ClientID,$RedirectUri,$SubscriptionKey,$AutorizationCode
+            Body = 'client_id={0}&grant_type=refresh_token&redirect_uri={1}&refresh_token={2}' -f $ClientID,$RedirectUri,$Oauth2.refresh_token
         }
-
         try {
-            #$Response = Invoke-RestMethod @HT -ErrorAction Stop
-            Invoke-RestMethod @HashTable -ErrorAction Stop
-            Write-Verbose -Message 'Successfully got access token'
+            $r = Invoke-RestMethod @HashTable -ErrorAction Stop
+            Write-Verbose -Message 'Successfully got oauth 2.0 refresh token'
         } catch {
             Throw $_
         }
+        if ($r) {
+            $global:MVPOauth2 = $r | 
+            Add-Member -MemberType NoteProperty -Name ValidUntil -Value ((Get-Date).AddSeconds($r.expires_in-1)) -Force -PassThru
+        }        
     } else {
-        Write-Warning -Message "No authorization code set"
+        Write-Verbose -Message 'The current Oauth2 access token is still valid'
+        
     }
 }
 End {}

--- a/MVP/Public/Get-MVPProfile.ps1
+++ b/MVP/Public/Get-MVPProfile.ps1
@@ -33,15 +33,17 @@ Begin {}
 Process {
     if (-not ($global:MVPPrimaryKey -and $global:MVPAuthorizationCode)) {
 
-	    Write-Warning -Message "You need to use Set-MVPConfiguration first to set the Primary Key"
+	    Write-Warning -Message 'You need to use Set-MVPConfiguration first to set the Primary Key'
 	    
     } else {
+        
+        Set-MVPConfiguration -SubscriptionKey $MVPPrimaryKey
 
         $Splat = @{
             Uri = 'https://mvpapi.azure-api.net/mvp/api/profile?'
             Headers = @{
                 'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey ;
-                Authorization = $Global:MVPAuthorizationCode
+                Authorization = $global:MVPAuthorizationCode
             }
             ErrorAction = 'Stop' ;
         }

--- a/MVP/Public/Set-MVPConfiguration.ps1
+++ b/MVP/Public/Set-MVPConfiguration.ps1
@@ -10,14 +10,14 @@ PARAM (
 Begin {}
 Process {
     try {
-        $output = Get-MVPOAuthAutorizationCode -ClientID $ClientID -SubscriptionKey $SubscriptionKey -ErrorAction Stop
+        Get-MVPOAuthAutorizationCode -ClientID $ClientID -SubscriptionKey $SubscriptionKey -ErrorAction Stop
         Write-Verbose -Message 'Successfully call the Get-MVPOAuthAutorizationCode function'
     } catch {
         Write-Warning -Message 'Something went wrong with the private function Get-MVPOAuthAutorizationCode'
     }
-    if ($output) {
+    if ($MVPOauth2) {
         $global:MVPPrimaryKey = $SubscriptionKey
-        $global:MVPAuthorizationCode = ('{0} {1}' -f $output.token_type,$output.access_token)
+        $global:MVPAuthorizationCode = ('{0} {1}' -f $MVPOauth2.token_type,$MVPOauth2.access_token)
         Write-Verbose -Message 'Successfully set the global variables MVPPrimaryKey and MVPAuthorizationCode'
     } else {
         Write-Warning -Message 'Failed to define an MVPAuthorizationCode variable'


### PR DESCRIPTION
Change the private function Get-MVPOAuthAutorizationCode to handle the validity of the OAuth 2.0 access token. Ask for permission(s) only if required.
Change for example the Get-MVPProfile public function to call the front-end Set-MVPConfiguration function to handle gracefully the Oauth token whenever required