### PR TITLE
Add functions for consideration Q&A endpoint

### DIFF
--- a/src/public/Get-MVPConsiderationAnswer.ps1
+++ b/src/public/Get-MVPConsiderationAnswer.ps1
@@ -1,0 +1,39 @@
+Function Get-MVPConsiderationAnswer {
+<#
+    .SYNOPSIS
+        Gets your award consideration question answers
+
+    .DESCRIPTION
+        Invoke the GetAnswers REST API to retrieve your currently active MVP award consideration question answers
+
+    .EXAMPLE
+        Get-MVPConsiderationAnswers
+
+        This example gets your current MVP award consideration question answers.
+#>
+[CmdletBinding()]
+Param()
+
+    if (-not ($global:MVPPrimaryKey -and $global:MVPAuthorizationCode)) {
+        Write-Warning -Message 'You need to use Set-MVPConfiguration first to set the Primary Key'
+    } else {
+        $Splat = @{
+            Uri = 'https://mvpapi.azure-api.net/mvp/api/awardconsideration/GetAnswers'
+            Headers = @{
+                'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey ;
+                Authorization = $Global:MVPAuthorizationCode
+            }
+            ErrorAction = 'Stop'
+        }
+
+        try {
+            Invoke-RestMethod @Splat
+        } catch {
+            if ($_.ErrorDetails.Message -like '*active and pending*') {
+                Write-Warning -Message ($_.ErrorDetails.Message | ConvertFrom-Json).Message
+            } else {
+                Write-Warning -Message "Failed to invoke the Get-MVPConsiderationAnswer API because $($_.Exception.Message)"
+            }
+        }
+    }
+}

--- a/src/public/Get-MVPConsiderationQuestion.ps1
+++ b/src/public/Get-MVPConsiderationQuestion.ps1
@@ -1,0 +1,37 @@
+Function Get-MVPConsiderationQuestion {
+<#
+    .SYNOPSIS
+        Gets your award consideration question Questions
+
+    .DESCRIPTION
+        Invoke the GetCurrentQuestions REST API to retrieve your currently active MVP award consideration questions.
+
+        Also returns answers if they have been registered.
+
+    .EXAMPLE
+        Get-MVPConsiderationQuestions
+
+        This example gets your current MVP award consideration question Questions.
+#>
+[CmdletBinding()]
+Param()
+
+    if (-not ($global:MVPPrimaryKey -and $global:MVPAuthorizationCode)) {
+        Write-Warning -Message 'You need to use Set-MVPConfiguration first to set the Primary Key'
+    } else {
+        $Splat = @{
+            Uri = 'https://mvpapi.azure-api.net/mvp/api/awardconsideration/getcurrentquestions'
+            Headers = @{
+                'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey ;
+                Authorization = $Global:MVPAuthorizationCode
+            }
+            ErrorAction = 'Stop'
+        }
+
+        try {
+            Invoke-RestMethod @Splat
+        } catch {
+            Write-Warning -Message "Failed to invoke the Get-MVPConsiderationQuestion API because $($_.Exception.Message)"
+        }
+    }
+}

--- a/src/public/Lock-MVPConsiderationAnswer.ps1
+++ b/src/public/Lock-MVPConsiderationAnswer.ps1
@@ -1,0 +1,46 @@
+Function Lock-MVPConsiderationAnswer {
+<#
+    .SYNOPSIS
+        Invoke the SubmitAnswers REST API
+
+    .DESCRIPTION
+        Submits and finalizes all answers for award consideration questions
+
+    .EXAMPLE
+    Lock-MVPConsiderationAnswer
+
+    This will submit and finalize all answers for MVP award consideration questions. No changes will be possible after execution.
+
+    .NOTES
+        https://github.com/lazywinadmin/MVP
+#>
+[CmdletBinding(SupportsShouldProcess = $true,
+               ConfirmImpact = 'High')]
+Param()
+Begin {}
+Process {
+    if (-not ($global:MVPPrimaryKey -and $global:MVPAuthorizationCode)) {
+        Write-Warning -Message 'You need to use Set-MVPConfiguration first to set the Primary Key'
+    } else {
+        $Splat = @{
+            Uri = 'https://mvpapi.azure-api.net/mvp/api/awardconsideration/SubmitAnswers'
+            Headers = @{
+                'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey
+                Authorization = $Global:MVPAuthorizationCode
+                }
+            Method = 'POST'
+            ErrorAction = 'Stop'
+        }
+
+        try {
+            Write-Verbose -Message "About to submit and finalize all MVP award consideration questions."
+            if ($PSCmdlet.ShouldProcess('Submitting and finalizing all MVP award consideration questions.')) {
+                Invoke-RestMethod @Splat
+            }
+        } catch {
+            Write-Warning -Message "Failed to invoke the SubmitAnswers API because $($_.Exception.Message)"
+        }
+    }
+}
+End {}
+}

--- a/src/public/New-MVPConsiderationAnswer.ps1
+++ b/src/public/New-MVPConsiderationAnswer.ps1
@@ -16,7 +16,7 @@ Function New-MVPConsiderationAnswer {
 
     .EXAMPLE
     $Answer = 'This is the answer to an example question.'
-    New-MVPContribution -AwardQuestionId 'f8dd332f-d1f9-4185-b123-16ae0b0be34f' -Answer $Answer
+    New-MVPConsiderationAnswer -AwardQuestionId 'f8dd332f-d1f9-4185-b123-16ae0b0be34f' -Answer $Answer
 
     This will create a new answer to an MVP award consideration question using the current session opened by Set-MVPConfiguration
 

--- a/src/public/New-MVPConsiderationAnswer.ps1
+++ b/src/public/New-MVPConsiderationAnswer.ps1
@@ -1,0 +1,68 @@
+Function New-MVPConsiderationAnswer {
+<#
+    .SYNOPSIS
+        Invoke the SaveAnswers REST API
+
+    .DESCRIPTION
+        Creates a new answer for an award consideration question
+
+    .PARAMETER Answer
+        Specifies the MVP's answer to the given award consideration question
+
+    .PARAMETER AwardQuestionId
+        Specifies the ID of the question being answered.
+
+        This can be retrieved using the Get-MVPConsiderationQuestion function.
+
+    .EXAMPLE
+    $Answer = 'This is the answer to an example question.'
+    New-MVPContribution -AwardQuestionId 'f8dd332f-d1f9-4185-b123-16ae0b0be34f' -Answer $Answer
+
+    This will create a new answer to an MVP award consideration question using the current session opened by Set-MVPConfiguration
+
+    .NOTES
+        https://github.com/lazywinadmin/MVP
+#>
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory,
+               ValueFromPipelineByPropertyName=$true)]
+    [String]$Answer,
+
+    [Parameter(Mandatory,
+               ValueFromPipelineByPropertyName=$true)]
+    [Guid]$AwardQuestionId
+)
+Begin {}
+Process {
+    if (-not ($global:MVPPrimaryKey -and $global:MVPAuthorizationCode)) {
+        Write-Warning -Message 'You need to use Set-MVPConfiguration first to set the Primary Key'
+    } else {
+        $Splat = @{
+            Uri = 'https://mvpapi.azure-api.net/mvp/api/awardconsideration/saveanswers'
+            Headers = @{
+                'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey
+                Authorization = $Global:MVPAuthorizationCode
+                ContentType = 'application/json'
+                }
+            Method = 'POST'
+            ContentType = 'application/json'
+            ErrorAction = 'Stop'
+        }
+
+        $Body = @"
+{
+    "AwardQuestionId": "$AwardQuestionId",
+    "Answer": "$Answer"
+}
+"@
+        try {
+            Write-Verbose -Message "About to create a new answer with Body $($Body)"
+            Invoke-RestMethod @Splat -Body $Body
+        } catch {
+            Write-Warning -Message "Failed to invoke the SaveAnswers API because $($_.Exception.Message)"
+        }
+    }
+}
+End {}
+}


### PR DESCRIPTION
This PR adds new functions, as per #36 to add support for the award consideration question and answer endpoints.

The two get ones are fairly self explanatory.

The "save answers" one, I went with New- to match the other POST endpoints, but it could be changed to Save- to match the name of the endpoint.

I had a similar naming problem with the "submit answers" one. I wanted to convey that this is a permanent operation so instead of a name like Submit- I went with Lock-.

To drive the permanent-neww home, I've also set it's confirmimpact to high and implemented whatif.

-----

Unlike last year, I can actually have access to the API now... unfortunately (or fortunately, I guess?) I'm not in a renewal consideration period so I can't test either of the POST endpoints, and the Get-Answer one returns a "no, not for you" message which I accounted for in the code.