### PR TITLE
Improves New-MVPContribution

### DIFF
--- a/src/public/New-MVPContribution.ps1
+++ b/src/public/New-MVPContribution.ps1
@@ -155,21 +155,25 @@ Process {
             ErrorAction = 'Stop'
         }
 
+        if (-not $Script:MVPCachedTypes) {
+            $Script:MVPCachedTypes = [ordered] @{
+                ContributionType = Get-MVPContributionType
+                ContributionArea = Get-MVPContributionArea -All
+                Visibility       = Get-MVPContributionVisibility
+            }
+        }
+
         # Verify the Contribution Type
-        $type = Get-MVPContributionType |
-            Where-Object -FilterScript {$_.name -eq $PSBoundParameters['ContributionType']}
+        $type = $Script:MVPCachedTypes['ContributionType'] | Where-Object -FilterScript { $_.name -eq $PSBoundParameters['ContributionType'] }
 
         # Verify the Contribution Technology
-        $Technology = Get-MVPContributionArea -All |
-            Where-Object -FilterScript {$_.name -eq $PSBoundParameters['ContributionTechnology']}
+        $Technology = $Script:MVPCachedTypes['ContributionArea'] | Where-Object -FilterScript { $_.name -eq $PSBoundParameters['ContributionTechnology'] }
 
         # Verify the Additional Technology
-        $AdditionalTechnologies = Get-MVPContributionArea -All |
-            Where-Object -FilterScript {$_.name -in $PSBoundParameters['AdditionalTechnologies']}
+        [Array] $AdditionalTechnologies = $Script:MVPCachedTypes['ContributionArea'] | Where-Object -FilterScript { $_.name -in $PSBoundParameters['AdditionalTechnologies'] }
 
         # Get the Visibility
-        $VisibilityObject = Get-MVPContributionVisibility |
-            Where-Object -FilterScript {$_.Description -eq $Visibility }
+        $VisibilityObject = $Script:MVPCachedTypes['Visibility'] | Where-Object -FilterScript { $_.Description -eq $Visibility }
 
         $HashTableContribution = @{
             "ContributionId"         = 0

--- a/src/public/New-MVPContribution.ps1
+++ b/src/public/New-MVPContribution.ps1
@@ -148,10 +148,10 @@ Process {
             Headers = @{
                 'Ocp-Apim-Subscription-Key' = $global:MVPPrimaryKey
                 Authorization = $Global:MVPAuthorizationCode
-                ContentType = 'application/json'
+                ContentType = 'application/json; charset=utf-8'
                 }
             Method = 'POST'
-            ContentType = 'application/json'
+            ContentType = 'application/json; charset=utf-8'
             ErrorAction = 'Stop'
         }
 


### PR DESCRIPTION
This changes:
- Ability to define more than one AdditionalTechnology (as the interface allows this, so does API - not sure if more than 2 are allowed so for now I've not blocked anything)
- Improved speed of the cmdlet by caching types. Otherwise with each submits four GET queries would execute unnessecary
- Hopefully fixes https://github.com/lazywinadmin/MVP/issues/19 as I was getting this error for some entries until I added UTF-8 in ContentType. Not sure if it's just luck that it started to work again or it really worked but no harm in doing so. 
- Uses ConvertTo-Json from Hashtable rather than the string-based body. Easier to set things PowerShell way.